### PR TITLE
fix: disable PiP for attachment video

### DIFF
--- a/client/src/features/chat/components/chat-desktop/VideoAttachmentPlayer.tsx
+++ b/client/src/features/chat/components/chat-desktop/VideoAttachmentPlayer.tsx
@@ -197,6 +197,8 @@ const VideoAttachmentPlayer: React.FC<VideoAttachmentPlayerProps> = ({ attachmen
           src={attachment.url}
           className="block h-auto max-h-[70vh] w-full bg-black object-contain"
           preload="metadata"
+                  disablePictureInPicture
+       
           poster={attachment.preview_url}
           onLoadedMetadata={handleLoadedMetadata}
           onTimeUpdate={handleTimeUpdate}


### PR DESCRIPTION
Prevent picture-in-picture (PiP) from being enabled on attachment videos by adding the disablePictureInPicture attribute to the <video> tag in VideoAttachmentPlayer.tsx. PiP remains available for video calls.